### PR TITLE
DR2-1329 Resources for e2e-tests

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -174,6 +174,26 @@ resource "aws_ecrpublic_repository" "judgment_package_anonymiser" {
   }
 }
 
+resource "aws_ecr_registry_scanning_configuration" "basic_scan_on_push" {
+  scan_type = "BASIC"
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+
+    repository_filter {
+      filter      = "*"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
+module "e2e_tests_repository" {
+  source          = "git::https://github.com/nationalarchives/da-terraform-modules.git//ecr"
+  repository_name = "e2e-tests"
+  allowed_principals = [
+    "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-e2e-tests-execution-role"
+  ]
+}
+
 module "image_deploy_role" {
   source             = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dr2-*" })

--- a/root_data.tf
+++ b/root_data.tf
@@ -11,3 +11,12 @@ data "aws_ssm_parameter" "staging_account_number" {
 data "aws_ssm_parameter" "prod_account_number" {
   name = "/mgmt/prod_account_number"
 }
+
+data "aws_ssm_parameter" "slack_token" {
+  name            = "/mgmt/slack/token"
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "dr2_notifications_slack_channel" {
+  name = "/mgmt/slack/notifications/channel"
+}

--- a/templates/eventbridge/image_scan_vulnerability_event_pattern.json.tpl
+++ b/templates/eventbridge/image_scan_vulnerability_event_pattern.json.tpl
@@ -1,0 +1,25 @@
+{
+  "source": ["aws.ecr"],
+  "detail-type": ["ECR Image Scan"],
+  "detail": {
+    "finding-severity-counts": {
+      "$or": [{
+        "CRITICAL": [{
+          "exists": true
+        }]
+      }, {
+        "HIGH": [{
+          "exists": true
+        }]
+      }, {
+        "MEDIUM": [{
+          "exists": true
+        }]
+      }, {
+        "LOW": [{
+          "exists": true
+        }]
+      }]
+    }
+  }
+}

--- a/templates/eventbridge/slack_message_input_template.json.tpl
+++ b/templates/eventbridge/slack_message_input_template.json.tpl
@@ -1,0 +1,4 @@
+{
+  "channel" : "${channel_id}",
+  "text": "${slackMessage}"
+}

--- a/templates/iam_policy/image_deploy.json.tpl
+++ b/templates/iam_policy/image_deploy.json.tpl
@@ -10,7 +10,13 @@
         "ecr-public:InitiateLayerUpload",
         "ecr-public:BatchCheckLayerAvailability",
         "ecr-public:PutImage",
-        "sts:GetServiceBearerToken"
+        "sts:GetServiceBearerToken",
+        "ecr:CompleteLayerUpload",
+        "ecr:GetAuthorizationToken",
+        "ecr:UploadLayerPart",
+        "ecr:InitiateLayerUpload",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage"
       ],
       "Resource": "*"
     }

--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -13,6 +13,7 @@
         "dynamodb:*",
         "ec2:*",
         "ecr:*",
+        "ecs:*",
         "elasticloadbalancing:*",
         "events:*",
         "glue:*",


### PR DESCRIPTION
This adds scan on push at the registry level which is the recommended
way of doing it now.
It also adds the task execution role to the repository policy so the
intg task can access the repository in the management account.
I've added ecs:* permissions to terraform so I can deploy the task
definition.
