### PR TITLE
Add staging account to repo policy

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -190,7 +190,8 @@ module "e2e_tests_repository" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules.git//ecr"
   repository_name = "e2e-tests"
   allowed_principals = [
-    "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-e2e-tests-execution-role"
+    "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-e2e-tests-execution-role",
+    "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-e2e-tests-execution-role"
   ]
 }
 


### PR DESCRIPTION
When I created this module, the staging roles didn't exist and you can't
add a role to an ECR policy that doesn't exist.

They exist now so this adds them in.
