### PR TITLE
DR2-1461 Move TNA to Preservica role.

### DIFF
--- a/environment_roles/main.tf
+++ b/environment_roles/main.tf
@@ -47,10 +47,11 @@ resource "aws_iam_openid_connect_provider" "openid_provider" {
 module "copy_tna_to_preservica_role" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
   assume_role_policy = templatefile("./templates/iam_role/tna_to_preservica_trust_policy.json.tpl", {
-    terraform_role_arn    = module.terraform_role.role_arn,
-    account_id            = data.aws_caller_identity.current.account_id,
-    management_account_id = var.management_account_number
-    title_environment     = title(var.environment)
+    terraform_role_arn        = module.terraform_role.role_arn,
+    account_id                = data.aws_caller_identity.current.account_id,
+    admin_role_arn            = var.management_developer_role_arn
+    terraform_github_role_arn = var.terraform_github_role_arn
+    title_environment         = title(var.environment)
   })
   name = local.tna_to_preservica_role_name
   policy_attachments = {

--- a/environment_roles/variables.tf
+++ b/environment_roles/variables.tf
@@ -5,3 +5,7 @@ variable "account_number" {}
 variable "management_account_number" {}
 
 variable "terraform_external_id" {}
+
+variable "terraform_github_role_arn" {}
+
+variable "management_developer_role_arn" {}

--- a/root.tf
+++ b/root.tf
@@ -218,7 +218,7 @@ module "image_scan_vulnerability_alerts" {
   event_pattern       = templatefile("${path.module}/templates/eventbridge/image_scan_vulnerability_event_pattern.json.tpl", {})
   name                = "mgmt-eventbridge-image-scan-vulnerabilities"
   api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
-  input_transformer = {
+  api_destination_input_transformer = {
     input_paths = {
       "repositoryName" = "$.detail.repository-name"
     }
@@ -237,7 +237,7 @@ module "enhanced_scanning_inspector_findings_alerts" {
   })
   name                = "mgmt-ecr-inspector-findings"
   api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
-  input_transformer = {
+  api_destination_input_transformer = {
     input_paths = {
       "vulnerabilityId" : "$.detail.packageVulnerabilityDetails.vulnerabilityId",
       "repositoryName" : "$.detail.resources[0].details.awsEcrContainerImage.repositoryName",
@@ -258,7 +258,7 @@ module "enhanced_scanning_inspector_initial_scan_alert" {
   })
   name                = "mgmt-ecr-inspector-initial-scan"
   api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
-  input_transformer = {
+  api_destination_input_transformer = {
     input_paths = {
       "totalFindings" : "$.detail.finding-severity-counts.TOTAL",
       "repositoryName" : "$.detail.repository-name"

--- a/root.tf
+++ b/root.tf
@@ -94,41 +94,49 @@ module "environment_roles_intg" {
   providers = {
     aws = aws.intg
   }
-  source                    = "./environment_roles"
-  account_number            = data.aws_ssm_parameter.intg_account_number.value
-  environment               = "intg"
-  management_account_number = data.aws_caller_identity.current.account_id
-  terraform_external_id     = module.terraform_config.terraform_config["intg"]["terraform_external_id"]
+  source                        = "./environment_roles"
+  account_number                = data.aws_ssm_parameter.intg_account_number.value
+  environment                   = "intg"
+  management_account_number     = data.aws_caller_identity.current.account_id
+  terraform_external_id         = module.terraform_config.terraform_config["intg"]["terraform_external_id"]
+  terraform_github_role_arn     = module.terraform_github_repository_iam.role_arn
+  management_developer_role_arn = data.aws_ssm_parameter.dev_admin_role.value
 }
 
 module "environment_roles_staging" {
   providers = {
     aws = aws.staging
   }
-  source                    = "./environment_roles"
-  account_number            = data.aws_ssm_parameter.staging_account_number.value
-  environment               = "staging"
-  management_account_number = data.aws_caller_identity.current.account_id
-  terraform_external_id     = module.terraform_config.terraform_config["staging"]["terraform_external_id"]
+  source                        = "./environment_roles"
+  account_number                = data.aws_ssm_parameter.staging_account_number.value
+  environment                   = "staging"
+  management_account_number     = data.aws_caller_identity.current.account_id
+  terraform_external_id         = module.terraform_config.terraform_config["staging"]["terraform_external_id"]
+  terraform_github_role_arn     = module.terraform_github_repository_iam.role_arn
+  management_developer_role_arn = data.aws_ssm_parameter.dev_admin_role.value
 }
 
 module "environment_roles_prod" {
   providers = {
     aws = aws.prod
   }
-  source                    = "./environment_roles"
-  account_number            = data.aws_ssm_parameter.prod_account_number.value
-  environment               = "prod"
-  management_account_number = data.aws_caller_identity.current.account_id
-  terraform_external_id     = module.terraform_config.terraform_config["prod"]["terraform_external_id"]
+  source                        = "./environment_roles"
+  account_number                = data.aws_ssm_parameter.prod_account_number.value
+  environment                   = "prod"
+  management_account_number     = data.aws_caller_identity.current.account_id
+  terraform_external_id         = module.terraform_config.terraform_config["prod"]["terraform_external_id"]
+  terraform_github_role_arn     = module.terraform_github_repository_iam.role_arn
+  management_developer_role_arn = data.aws_ssm_parameter.dev_admin_role.value
 }
 
 module "environment_roles_mgmt" {
-  source                    = "./environment_roles"
-  account_number            = data.aws_caller_identity.current.account_id
-  environment               = "mgmt"
-  management_account_number = data.aws_caller_identity.current.account_id
-  terraform_external_id     = module.terraform_config.terraform_config["mgmt"]["terraform_external_id"]
+  source                        = "./environment_roles"
+  account_number                = data.aws_caller_identity.current.account_id
+  environment                   = "mgmt"
+  management_account_number     = data.aws_caller_identity.current.account_id
+  terraform_external_id         = module.terraform_config.terraform_config["mgmt"]["terraform_external_id"]
+  terraform_github_role_arn     = module.terraform_github_repository_iam.role_arn
+  management_developer_role_arn = data.aws_ssm_parameter.dev_admin_role.value
 }
 
 module "code_deploy_bucket" {

--- a/root_data.tf
+++ b/root_data.tf
@@ -20,3 +20,7 @@ data "aws_ssm_parameter" "slack_token" {
 data "aws_ssm_parameter" "dr2_notifications_slack_channel" {
   name = "/mgmt/slack/notifications/channel"
 }
+
+data "aws_ssm_parameter" "dev_admin_role" {
+  name = "/mgmt/developer_role"
+}

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -20,6 +20,12 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/IntgTerraformBootstrapRole"
     session_name = "terraform-backend"
   }
+  default_tags {
+    tags = {
+      Environment = "intg"
+      CreatedBy   = "dr2-terraform-backend"
+    }
+  }
 }
 
 provider "aws" {
@@ -29,6 +35,12 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/StagingTerraformBootstrapRole"
     session_name = "terraform-backend"
   }
+  default_tags {
+    tags = {
+      Environment = "staging"
+      CreatedBy   = "dr2-terraform-backend"
+    }
+  }
 }
 
 provider "aws" {
@@ -37,5 +49,11 @@ provider "aws" {
   assume_role {
     role_arn     = "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/ProdTerraformBootstrapRole"
     session_name = "terraform-backend"
+  }
+  default_tags {
+    tags = {
+      Environment = "prod"
+      CreatedBy   = "dr2-terraform-backend"
+    }
   }
 }

--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -10,6 +10,7 @@
         "cloudtrail:*",
         "cloudwatch:*",
         "config:*",
+        "datasync:*",
         "dynamodb:*",
         "ec2:*",
         "ecr:*",

--- a/templates/iam_policy/tna_to_preservica_copy.json.tpl
+++ b/templates/iam_policy/tna_to_preservica_copy.json.tpl
@@ -1,0 +1,80 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject",
+        "s3:GetObjectTagging",
+        "s3:PutObjectTagging"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk1/*",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk2/*",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk3/*",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk4/*",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.put.holding/*",
+        "arn:aws:s3:::${ingest_staging_cache_bucket_name}/*"
+      ],
+      "Sid": "readWriteTnaAndPreservica"
+    },
+    {
+      "Action": [
+        "datasync:DescribeTaskExecution",
+        "datasync:CancelTaskExecution",
+        "datasync:DescribeLocation*",
+        "datasync:CreateTask",
+        "datasync:DescribeTask",
+        "datasync:DescribeLocation*",
+        "datasync:StartTaskExecution",
+        "datasync:TagResource",
+        "datasync:ListTagsForResource",
+        "datasync:DeleteLocation",
+        "datasync:DeleteTask",
+        "datasync:UpdateTask",
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:datasync:eu-west-2:${account_id}:task/*",
+        "arn:aws:datasync:eu-west-2:${account_id}:location/*",
+        "arn:aws:datasync:eu-west-2:${account_id}:task/*/execution/*",
+        "${tna_to_preservica_role_arn}"
+      ],
+      "Sid": "dataSyncTasks"
+    },
+    {
+      "Sid": "dataSyncList",
+      "Effect": "Allow",
+      "Action": [
+        "datasync:CreateLocationS3",
+        "datasync:ListLocations",
+        "datasync:ListTaskExecutions",
+        "datasync:ListTasks",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk1",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk2",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk3",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.bulk4",
+        "arn:aws:s3:::com.preservica.${preservica_tenant}.put.holding",
+        "arn:aws:s3:::${ingest_staging_cache_bucket_name}"
+      ],
+      "Sid": "listBucketPreservica"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
+++ b/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${management_account_id}:root"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "AllowStepFunctionRole",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:role/${title_environment}-ingest-role"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "AllowAWSDataSync",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "datasync.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
+++ b/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${management_account_id}:root"
+        "AWS": ["${terraform_github_role_arn}", "${admin_role_arn}"]
       },
       "Action": "sts:AssumeRole"
     },


### PR DESCRIPTION
To create the DataSync locations and tasks, the role which creates it needs to be able to access the Preservica bucket. This means that terraform needs to be able to assume the role which means it needs to already exist in dr2-terraform-backend.

It’s probably safer to move the resources from the terraform environments state to the terraform backend state rather than delete and recreate in case we break something.

This role is a bit of a weird hybrid but it's working.
