### PR TITLE
DR2-1550 Update code deploy bucket policy.

### DIFF
--- a/templates/s3/code_deploy.json.tpl
+++ b/templates/s3/code_deploy.json.tpl
@@ -26,8 +26,11 @@
           "arn:aws:iam::${prod_account_number}:role/ProdDPGithubActionsDeployLambdaRole"
         ]
       },
-      "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::mgmt-dp-code-deploy/*"
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::mgmt-dp-code-deploy/*",
+        "arn:aws:s3:::mgmt-dp-code-deploy"
+      ]
     }
   ]
 }


### PR DESCRIPTION
With the monorepo, we want to deploy all jars in a bucket with a given
prefix which means we need to be able to do ListBucket
