### PR TITLE
DR2-1638 Lock down GitHub roles.

### DIFF
--- a/environment_roles/main.tf
+++ b/environment_roles/main.tf
@@ -32,7 +32,7 @@ module "custodian_role" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.root}/templates/iam_role/github_assume_role.json.tpl", {
     account_id   = data.aws_caller_identity.current.account_id,
-    repo_filters = jsonencode(module.custodian_repo_filters.repository_environments["dr2-${var.environment}"])
+    repo_filters = jsonencode(concat(module.custodian_repo_filters.repository_environments["dr2-${var.environment}"], ["repo:nationalarchives/tna-custodian:pull_request"]))
   })
   name = "${title(var.environment)}DR2GithubActionsCustodianDeployRole"
   policy_attachments = {

--- a/environment_roles/main.tf
+++ b/environment_roles/main.tf
@@ -24,7 +24,7 @@ module "terraform_policy" {
 
 module "custodian_repo_filters" {
   source       = "../github_repository_filters"
-  repositories = [{ name : "tna-custodian", "default_branch" : "master" }]
+  repositories = [{ name : "tna-custodian", "branch" : "master" }]
   environments = ["dr2-intg", "dr2-staging", "dr2-prod", "dr2-mgmt"]
 }
 

--- a/github_repository_filters/locals.tf
+++ b/github_repository_filters/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  environment_filters = { for environment in var.environments : environment => concat(flatten([
+    for repository in var.repositories : [
+      "repo:${var.organisation}/${repository.name}:environment:${environment}"
+    ]
+    ]), local.repository_branch_filters)
+  }
+  repository_branch_filters = [
+    for repository in var.repositories : "repo:${var.organisation}/${repository.name}:ref:refs/heads/${repository.default_branch}"
+  ]
+}

--- a/github_repository_filters/locals.tf
+++ b/github_repository_filters/locals.tf
@@ -6,6 +6,6 @@ locals {
     ]), local.repository_branch_filters)
   }
   repository_branch_filters = [
-    for repository in var.repositories : "repo:${var.organisation}/${repository.name}:ref:refs/heads/${repository.default_branch}"
+    for repository in var.repositories : "repo:${var.organisation}/${repository.name}:ref:refs/heads/${repository.branch}"
   ]
 }

--- a/github_repository_filters/outputs.tf
+++ b/github_repository_filters/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_filters" {
+  value = toset(flatten(values(local.environment_filters)))
+}
+
+output "repository_environments" {
+  value = local.environment_filters
+}
+
+

--- a/github_repository_filters/outputs.tf
+++ b/github_repository_filters/outputs.tf
@@ -1,5 +1,9 @@
-output "repository_filters" {
+output "repository_environment_filters" {
   value = toset(flatten(values(local.environment_filters)))
+}
+
+output "repository_filters" {
+  value = local.repository_branch_filters
 }
 
 output "repository_environments" {

--- a/github_repository_filters/outputs.tf
+++ b/github_repository_filters/outputs.tf
@@ -2,10 +2,6 @@ output "repository_environment_filters" {
   value = toset(flatten(values(local.environment_filters)))
 }
 
-output "repository_filters" {
-  value = local.repository_branch_filters
-}
-
 output "repository_environments" {
   value = local.environment_filters
 }

--- a/github_repository_filters/variables.tf
+++ b/github_repository_filters/variables.tf
@@ -1,0 +1,12 @@
+variable "environments" {
+  type    = list(string)
+  default = []
+}
+
+variable "repositories" {
+  type = list(object({ name : string, default_branch : optional(string, "main") }))
+}
+
+variable "organisation" {
+  default = "nationalarchives"
+}

--- a/github_repository_filters/variables.tf
+++ b/github_repository_filters/variables.tf
@@ -4,7 +4,7 @@ variable "environments" {
 }
 
 variable "repositories" {
-  type = list(object({ name : string, default_branch : optional(string, "main") }))
+  type = list(object({ name : string, branch : optional(string, "main") }))
 }
 
 variable "organisation" {

--- a/root.tf
+++ b/root.tf
@@ -4,8 +4,8 @@ locals {
   environments                 = toset(["intg", "staging", "prod"])
   dev_notifications_channel_id = "C052LJASZ08"
   department_terraform_repositories = [
-    { name : "tna-custodian", default_branch : "master" },
-    { name : "tdr-aws-accounts", default_branch : "master" }
+    { name : "tna-custodian", branch : "master" },
+    { name : "tdr-aws-accounts", branch : "master" }
   ]
   department_terraform_github_environments = [
     "dr2-intg",
@@ -14,7 +14,7 @@ locals {
     "dr2-mgmt"
   ]
   dr2_terraform_repositories = [
-    { name : "dr2-terraform-environments" }
+    { name : "dr2-terraform-environments", branch = "*" }
   ]
   dr2_terraform_github_environments = [
     "intg",

--- a/root.tf
+++ b/root.tf
@@ -84,8 +84,11 @@ module "dp_terraform_dynamo" {
 module "terraform_github_repository_iam" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
-    account_id   = data.aws_caller_identity.current.account_id,
-    repo_filters = jsonencode(["repo:nationalarchives/dr2-terraform-github-repositories:pull_request"])
+    account_id = data.aws_caller_identity.current.account_id,
+    repo_filters = jsonencode([
+      "repo:nationalarchives/dr2-terraform-github-repositories:pull_request",
+      "repo:nationalarchives/dr2-terraform-github-repositories:ref:refs/heads/main"
+    ])
   })
   name = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {

--- a/root.tf
+++ b/root.tf
@@ -215,7 +215,7 @@ module "code_build_role" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
     account_id   = data.aws_caller_identity.current.account_id,
-    repo_filters = jsonencode(module.dr2_code_deploy_repository_filters.repository_filters)
+    repo_filters = jsonencode(module.dr2_code_deploy_repository_filters.repository_environment_filters)
   })
   name = "MgmtDPGithubCodeDeploy"
   policy_attachments = {

--- a/root.tf
+++ b/root.tf
@@ -25,7 +25,7 @@ locals {
   ]
   dr2_code_deploy_repositories  = [{ name : "dr2-ingest" }, { name : "dr2-ip-lock-checker" }]
   dr2_code_deploy_environments  = ["intg", "staging", "prod"]
-  dr2_image_deploy_repositories = [{ name : "dr2-e2e-tests" }, { name : "dr2-court-document-package-anonymiser" }]
+  dr2_image_deploy_repositories = [{ name : "dr2-e2e-tests" }, { name : "dr2-court-document-package-anonymiser" }, { name : "dr2-disaster-recovery" }]
   environments_roles = {
     intg    = module.environment_roles_intg.terraform_role_arn
     staging = module.environment_roles_staging.terraform_role_arn

--- a/root.tf
+++ b/root.tf
@@ -4,7 +4,7 @@ locals {
   environments                 = toset(["intg", "staging", "prod"])
   dev_notifications_channel_id = "C052LJASZ08"
   department_terraform_repositories = [
-    { name : "tna-custodian", branch : "master" },
+    { name : "tna-custodian", branch : "*" },
     { name : "tdr-aws-accounts", branch : "master" }
   ]
   department_terraform_github_environments = [
@@ -119,7 +119,8 @@ module "terraform_github_terraform_environments" {
     account_id = data.aws_caller_identity.current.account_id,
     repo_filters = jsonencode(concat(
       module.department_terraform_repository_filters.repository_environments["dr2-${each.key}"],
-      module.dr2_terraform_repository_filters.repository_environments[each.key]
+      module.dr2_terraform_repository_filters.repository_environments[each.key],
+      ["repo:nationalarchives/tna-custodian:pull_request"]
     ))
   })
   name = "MgmtDPGithubTerraformEnvironmentsRole${title(each.key)}"

--- a/root.tf
+++ b/root.tf
@@ -85,7 +85,7 @@ module "terraform_github_repository_iam" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
     account_id   = data.aws_caller_identity.current.account_id,
-    repo_filters = jsonencode(["repo:nationalarchives/dr2-terraform-github-repositories:ref:refs/heads/main"])
+    repo_filters = jsonencode(["repo:nationalarchives/dr2-terraform-github-repositories:pull_request"])
   })
   name = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {

--- a/root.tf
+++ b/root.tf
@@ -54,6 +54,7 @@ module "dr2_code_deploy_repository_filters" {
 module "dr2_image_deploy_repository_filters" {
   source       = "./github_repository_filters"
   repositories = local.dr2_image_deploy_repositories
+  environments = local.dr2_code_deploy_environments
 }
 
 module "terraform_config" {
@@ -278,7 +279,7 @@ module "image_deploy_role" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
     account_id   = data.aws_caller_identity.current.account_id,
-    repo_filters = jsonencode(module.dr2_image_deploy_repository_filters.repository_filters)
+    repo_filters = jsonencode(module.dr2_image_deploy_repository_filters.repository_environment_filters)
   })
   name = "MgmtDPGithubImageDeploy"
   policy_attachments = {

--- a/templates/iam_policy/image_deploy.json.tpl
+++ b/templates/iam_policy/image_deploy.json.tpl
@@ -4,19 +4,21 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ecr-public:CompleteLayerUpload",
-        "ecr-public:GetAuthorizationToken",
-        "ecr-public:UploadLayerPart",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:PutImage",
-        "sts:GetServiceBearerToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
         "ecr:CompleteLayerUpload",
         "ecr:GetAuthorizationToken",
-        "ecr:UploadLayerPart",
+        "ecr:GetDownloadUrlForLayer",
         "ecr:InitiateLayerUpload",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:PutImage"
+        "ecr-public:BatchCheckLayerAvailability",
+        "ecr-public:CompleteLayerUpload",
+        "ecr-public:GetAuthorizationToken",
+        "ecr-public:InitiateLayerUpload",
+        "ecr-public:PutImage",
+        "ecr-public:UploadLayerPart",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart",
+        "sts:GetServiceBearerToken"
       ],
       "Resource": "*"
     }

--- a/templates/iam_role/github_assume_role.json.tpl
+++ b/templates/iam_role/github_assume_role.json.tpl
@@ -12,7 +12,7 @@
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
         },
         "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:nationalarchives/${repo_filter}"
+          "token.actions.githubusercontent.com:sub": ${repo_filters}
         }
       }
     }

--- a/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
+++ b/templates/iam_role/tna_to_preservica_trust_policy.json.tpl
@@ -13,7 +13,6 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${account_id}:role/${title_environment}-ingest-role",
           "arn:aws:iam::${account_id}:role/${environment}-dr2-ingest-role"
         ]
       },


### PR DESCRIPTION
A lot of the complexity here comes from the fact that we're using the
same role to run terraform for dr2-terraform-environments,
tdr-aws-accounts and tna-custodian.

Whether this is a good idea is a subject for another time but it's
basically set up like this:

If a role is for a specific environment, e.g. MgmtDPGithubTerraformEnvironmentsRoleIntg
then that role has permissions for the intg environment on GitHub.

The MgmtDPGithubTerraformEnvironmentsRole${environment} role needs permissions for all branches because it's used to run the tests on branches before they're merged. There's not much we can do about that.

If the role is for all environments, e.g. MgmtDPGithubCodeDeploy then
this includes all environments.

I've created a module in here to replace duplication. I don't think
we'll need it elsewhere as these are the most complicated permissions
so I've not put it in da-terraform-modules for now.

I've also sneaked in a change to the docker image deploy role as it was missing permissions to pull. 
