### PR TITLE
DR2-2007 Remove mgmt terraform roles and use account ones.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.56.0"
   hashes = [
     "h1:09fAczBASw/S5fgA35pxTCjtUgTn1Q+u9AxVdu9PYT0=",
+    "h1:F9Ad0SflY+F0M+1F5FohJlQ573cVpCGn+c7hIvJRwkg=",
     "zh:626ada4e076bd852fb7fc3d0722f17a0eddd87356d94cfce8b3595a520e8d91d",
     "zh:6b31e0c5b60d830a623ae9cc7d8cf2db74f75735d83097c659607c8a6276adaf",
     "zh:774d02a1c5ddcc9b5efbfe86bc967f4af8a52b8cb5880b2f5d1b255e5b0868ba",

--- a/environment_roles/main.tf
+++ b/environment_roles/main.tf
@@ -7,9 +7,13 @@ locals {
 }
 
 module "terraform_role" {
-  source             = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
-  assume_role_policy = templatefile("./templates/iam_role/account_assume_role.json.tpl", { account_id = var.management_account_number, external_id = var.terraform_external_id })
-  name               = "${title(var.environment)}TerraformRole"
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
+  assume_role_policy = templatefile("./templates/iam_role/account_assume_role.json.tpl", {
+    admin_role_arn = data.aws_ssm_parameter.dev_admin_role.value
+    account_id     = var.account_number,
+    repo_filters   = var.terraform_repository_filters
+  })
+  name = "${title(var.environment)}TerraformRole"
   policy_attachments = {
     terraform_policy = module.terraform_policy.policy_arn
   }
@@ -19,7 +23,7 @@ module "terraform_role" {
 module "terraform_policy" {
   source        = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
   name          = "${title(var.environment)}TerraformPolicy"
-  policy_string = templatefile("./templates/iam_policy/terraform_policy.json.tpl", { account_id = var.account_number, environment = var.environment, environment_title = title(var.environment) })
+  policy_string = templatefile("./templates/iam_policy/terraform_policy.json.tpl", { account_id = var.account_number, environment = var.environment, environment_title = title(var.environment), management_account_id = var.management_account_number })
 }
 
 module "custodian_repo_filters" {
@@ -59,8 +63,8 @@ module "copy_tna_to_preservica_role" {
   assume_role_policy = templatefile("./templates/iam_role/tna_to_preservica_trust_policy.json.tpl", {
     terraform_role_arn        = module.terraform_role.role_arn,
     account_id                = data.aws_caller_identity.current.account_id,
-    admin_role_arn            = var.management_developer_role_arn
-    terraform_github_role_arn = var.terraform_github_role_arn
+    admin_role_arn            = data.aws_ssm_parameter.dev_admin_role.value
+    terraform_github_role_arn = module.terraform_role.role_arn
     title_environment         = title(var.environment)
     environment               = var.environment
   })
@@ -83,3 +87,10 @@ module "copy_tna_to_preservica_policy" {
   })
 }
 
+resource "aws_cloudwatch_log_group" "terraform_plan_log_group" {
+  name = "terraform-plan-outputs-${var.environment}"
+}
+
+data "aws_ssm_parameter" "dev_admin_role" {
+  name = "/${var.environment}/developer_role"
+}

--- a/environment_roles/variables.tf
+++ b/environment_roles/variables.tf
@@ -4,8 +4,4 @@ variable "account_number" {}
 
 variable "management_account_number" {}
 
-variable "terraform_external_id" {}
-
-variable "terraform_github_role_arn" {}
-
-variable "management_developer_role_arn" {}
+variable "terraform_repository_filters" {}

--- a/root_data.tf
+++ b/root_data.tf
@@ -21,6 +21,3 @@ data "aws_ssm_parameter" "dr2_notifications_slack_channel" {
   name = "/mgmt/slack/notifications/channel"
 }
 
-data "aws_ssm_parameter" "dev_admin_role" {
-  name = "/mgmt/developer_role"
-}

--- a/templates/dynamo/lock_table_policy.json.tpl
+++ b/templates/dynamo/lock_table_policy.json.tpl
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAccountAccess",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ${terraform_role_arns}
+      },
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem"
+      ],
+      "Resource": "${table_arn}"
+    }
+  ]
+}

--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -55,6 +55,23 @@
         "arn:aws:iam::${account_id}:policy/${environment_title}*",
         "arn:aws:iam::${account_id}:instance-profile/${environment}*"
       ]
+    },
+    {
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::mgmt-dp-terraform-state",
+        "arn:aws:s3:::mgmt-dp-terraform-state/*",
+        "arn:aws:dynamodb:eu-west-2:${management_account_id}:table/mgmt-dp-terraform-state-lock"
+      ]
     }
   ]
 }

--- a/templates/iam_policy/tna_to_preservica_copy.json.tpl
+++ b/templates/iam_policy/tna_to_preservica_copy.json.tpl
@@ -27,6 +27,7 @@
         "datasync:CancelTaskExecution",
         "datasync:DescribeLocation*",
         "datasync:CreateTask",
+        "datasync:CreateLocationS3",
         "datasync:DescribeTask",
         "datasync:DescribeLocation*",
         "datasync:StartTaskExecution",

--- a/templates/iam_role/account_assume_role.json.tpl
+++ b/templates/iam_role/account_assume_role.json.tpl
@@ -4,12 +4,22 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${account_id}:root"
+        "AWS": "${admin_role_arn}"
       },
-      "Action": "sts:AssumeRole",
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "sts:ExternalId": "${external_id}"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": ${repo_filters}
         }
       }
     }

--- a/templates/s3/terraform_state_policy.json.tpl
+++ b/templates/s3/terraform_state_policy.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Allow account roles access",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ${terraform_role_arns}
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::mgmt-dp-terraform-state",
+        "arn:aws:s3:::mgmt-dp-terraform-state/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This deletes the management roles which assumed the roles in the
environment accounts and updates the trust policies on those accounts to
allow GitHub to run them.

It also updates the bucket policy for the state bucket and the resource
policy for the lock table.

This will need https://github.com/nationalarchives/da-terraform-modules/pull/82 to be merged 
before this can be deployed.
