### PR TITLE
Remove explicit deny.

### DIFF
--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.WORKFLOW_TOKEN }}
+      - uses: hashicorp/setup-terraform@v3
       - uses: nationalarchives/dr2-github-actions/.github/actions/run-git-secrets@main
       - uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@main
         if: failure()

--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -43,13 +43,6 @@
       "Resource": "*"
     },
     {
-      "Action": [
-        "iam:PassRole"
-      ],
-      "Effect": "Deny",
-      "Resource": "*"
-    },
-    {
       "Effect": "Allow",
       "Action": [
         "iam:*"


### PR DESCRIPTION
The iam:* statement is limited to roles within the account which start
with the environment name. It's not foolproof but terraform needs
PassRole to create lambdas.
