### PR TITLE
Add org-wiz-access-role to terraform policy.

### DIFF
--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -52,6 +52,7 @@
         "arn:aws:iam::${account_id}:user/${environment}-dr2-custodial-copy",
         "arn:aws:iam::${account_id}:role/${environment}*",
         "arn:aws:iam::${account_id}:role/${environment_title}*",
+        "arn:aws:iam::${account_id}:role/org-wiz-access-role",
         "arn:aws:iam::${account_id}:role/aws-service-role*",
         "arn:aws:iam::${account_id}:policy/${environment}*",
         "arn:aws:iam::${account_id}:policy/${environment_title}*",


### PR DESCRIPTION
We want to add this role to the KMS key.

I'ts simplest to use a data block to get the role arn and for that,
terraform needs this.

This has already been deployed.
