### PR TITLE
Remove management terraform account.

### DIFF
--- a/environment_roles/main.tf
+++ b/environment_roles/main.tf
@@ -8,6 +8,7 @@ locals {
 
 module "terraform_role" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
+  count  = var.environment == "mgmt" ? 0 : 1
   assume_role_policy = templatefile("./templates/iam_role/account_assume_role.json.tpl", {
     admin_role_arn = data.aws_ssm_parameter.dev_admin_role.value
     account_id     = var.account_number,

--- a/environment_roles/outputs.tf
+++ b/environment_roles/outputs.tf
@@ -1,4 +1,4 @@
 output "terraform_role_arn" {
-  value     = module.terraform_role.role_arn
+  value     = var.environment == "mgmt" ? "" : module.terraform_role[0].role_arn
   sensitive = true
 }


### PR DESCRIPTION
We're creating a role for deploying DR2 in the management account which
we don't do so this can be removed.
