### PR TITLE
DR2-2708 Add eventbridge permissions.

### DIFF
--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -13,12 +13,6 @@ jobs:
           submodules: recursive
           token: ${{ secrets.WORKFLOW_TOKEN }}
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-      - uses: nationalarchives/dr2-github-actions/.github/actions/run-git-secrets@917201e254f112ff041b952dae76ef767cae7378
-      - uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@917201e254f112ff041b952dae76ef767cae7378
-        if: failure()
-        with:
-          message: ":warning: Secrets found in repository dr2-terraform-backend"
-          slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Configure AWS credentials for S3 state file access
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:

--- a/root.tf
+++ b/root.tf
@@ -24,9 +24,9 @@ locals {
     "sbox",
     "mgmt"
   ]
-  dr2_code_deploy_repositories  = [{ name : "dr2-ingest" }, { name : "dr2-ip-lock-checker" }, { name : "dr2-ingest-cc-notification-handler" }]
+  dr2_code_deploy_repositories  = [{ name : "dr2-ingest" }]
   dr2_code_deploy_environments  = ["intg", "staging", "prod"]
-  dr2_image_deploy_repositories = [{ name : "dr2-e2e-tests" }, { name : "dr2-court-document-package-anonymiser" }, { name : "dr2-custodial-copy" }]
+  dr2_image_deploy_repositories = [{ name : "dr2-custodial-copy" }]
   environments_roles = {
     intg    = module.environment_roles_intg.terraform_role_arn
     staging = module.environment_roles_staging.terraform_role_arn
@@ -388,7 +388,7 @@ module "library_put_events_role" {
 
 module "library_put_events_policy" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_policy"
-  name   = "mgmt-library-put-events-"
+  name   = "mgmt-library-put-events-policy"
   policy_string = templatefile("${path.module}/templates/iam_policy/put_event.json.tpl", {
     event_bus_arn = "arn:aws:events:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:event-bus/default"
   })

--- a/root.tf
+++ b/root.tf
@@ -287,9 +287,11 @@ module "image_deploy_role" {
 }
 
 module "image_deploy_policy" {
-  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_policy"
-  name          = "MgmtDPGithubImageDeployPolicy"
-  policy_string = templatefile("${path.module}/templates/iam_policy/image_deploy.json.tpl", {})
+  source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_policy"
+  name   = "MgmtDPGithubImageDeployPolicy"
+  policy_string = templatefile("${path.module}/templates/iam_policy/image_deploy.json.tpl", {
+    event_bus_arn = "arn:aws:events:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:event-bus/default"
+  })
 }
 
 module "eventbridge_alarm_notifications_destination" {
@@ -348,6 +350,22 @@ module "enhanced_scanning_inspector_initial_scan_alert" {
     input_template = templatefile("${path.module}/templates/eventbridge/slack_message_input_template.json.tpl", {
       channel_id   = local.dev_notifications_channel_id
       slackMessage = ":alert-noflash-slow: Initial scan complete for `<repositoryName>` <totalFindings> vulnerabilities found"
+    })
+  }
+}
+
+module "dev_slack_message_eventbridge_rule" {
+  source              = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
+  api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
+  event_pattern       = templatefile("${path.module}/templates/eventbridge/custom_detail_type_event_pattern.json.tpl", { detail_type = "DR2DevMessage" })
+  name                = "mgmt-dr2-eventbridge-dev-slack-message"
+  api_destination_input_transformer = {
+    input_paths = {
+      "slackMessage" = "$.detail.slackMessage"
+    }
+    input_template = templatefile("${path.module}/templates/eventbridge/slack_message_input_template.json.tpl", {
+      channel_id   = local.dev_notifications_channel_id
+      slackMessage = "<slackMessage>"
     })
   }
 }

--- a/root.tf
+++ b/root.tf
@@ -376,8 +376,7 @@ module "library_put_events_role" {
     account_id = data.aws_caller_identity.current.account_id,
     repo_filters = jsonencode([
       "repo:nationalarchives/da-aws-clients:ref:refs/heads/main",
-      "repo:nationalarchives/dr2-preservica-client:ref:refs/heads/main",
-      "repo:nationalarchives/da-aws-clients:ref:refs/heads/DR2-2713-remove-dependency-from-aws-clients"
+      "repo:nationalarchives/dr2-preservica-client:ref:refs/heads/main"
     ])
   })
   name = "mgmt-library-put-events-role"

--- a/root.tf
+++ b/root.tf
@@ -369,3 +369,28 @@ module "dev_slack_message_eventbridge_rule" {
     })
   }
 }
+
+module "library_put_events_role" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
+    account_id = data.aws_caller_identity.current.account_id,
+    repo_filters = jsonencode([
+      "repo:nationalarchives/da-aws-clients:ref:refs/heads/main",
+      "repo:nationalarchives/dr2-preservica-client:ref:refs/heads/main",
+      "repo:nationalarchives/da-aws-clients:ref:refs/heads/DR2-2713-remove-dependency-from-aws-clients"
+    ])
+  })
+  name = "mgmt-library-put-events-role"
+  policy_attachments = {
+    image_deploy_policy = module.library_put_events_policy.policy_arn
+  }
+  tags = {}
+}
+
+module "library_put_events_policy" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules.git//iam_policy"
+  name   = "mgmt-library-put-events-"
+  policy_string = templatefile("${path.module}/templates/iam_policy/put_event.json.tpl", {
+    event_bus_arn = "arn:aws:events:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:event-bus/default"
+  })
+}

--- a/root_data.tf
+++ b/root_data.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current_region" {}
+
 data "aws_ssm_parameter" "intg_account_number" {
   name = "/mgmt/intg_account_number"
 }

--- a/templates/eventbridge/custom_detail_type_event_pattern.json.tpl
+++ b/templates/eventbridge/custom_detail_type_event_pattern.json.tpl
@@ -1,0 +1,3 @@
+{
+  "detail-type": ["${detail_type}"]
+}

--- a/templates/iam_policy/image_deploy.json.tpl
+++ b/templates/iam_policy/image_deploy.json.tpl
@@ -21,6 +21,12 @@
         "sts:GetServiceBearerToken"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "PutEvents",
+      "Effect": "Allow",
+      "Action": "events:PutEvents",
+      "Resource": "${event_bus_arn}"
     }
   ]
 }

--- a/templates/iam_policy/put_event.json.tpl
+++ b/templates/iam_policy/put_event.json.tpl
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PutEvents",
+      "Effect": "Allow",
+      "Action": "events:PutEvents",
+      "Resource": "${event_bus_arn}"
+    }
+  ]
+}


### PR DESCRIPTION
This will allow us to send slack messages in the deploy job via
eventbridge

I've also removed the dr2-github-actions workflow calls as we don't need git-secrets any more.

I've added a role with a policy for the da-aws-clients and dr2-preservica-client repos which only has permissions to publish to the default event bus so we can send messages that way.