### PR TITLE
Allow terraform to create Roles Anywhere trust anchors and profiles

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -162,6 +162,9 @@ module "custodial_copy_backend_repository" {
   repository_name = "dr2-custodial-copy-backend"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:user/intg-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:user/staging-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:user/prod-dr2-custodial-copy"
@@ -177,6 +180,9 @@ module "custodial_copy_db_builder_repository" {
   repository_name = "dr2-custodial-copy-db-builder"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:user/intg-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:user/staging-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:user/prod-dr2-custodial-copy"
@@ -192,6 +198,9 @@ module "custodial_copy_webapp_repository" {
   repository_name = "dr2-custodial-copy-webapp"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:user/intg-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:user/staging-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:user/prod-dr2-custodial-copy"
@@ -207,6 +216,9 @@ module "custodial_copy_reindexer_repository" {
   repository_name = "dr2-custodial-copy-re-indexer"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:user/intg-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:user/staging-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:user/prod-dr2-custodial-copy"
@@ -222,6 +234,9 @@ module "custodial_copy_confirmer_repository" {
   repository_name = "dr2-custodial-copy-confirmer"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:user/intg-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:user/staging-dr2-custodial-copy",
       "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:user/prod-dr2-custodial-copy"

--- a/templates/iam_policy/terraform_policy.json.tpl
+++ b/templates/iam_policy/terraform_policy.json.tpl
@@ -25,6 +25,7 @@
         "logs:*",
         "organizations:DescribeOrganization",
         "pipes:*",
+        "rolesanywhere:*",
         "route53:*",
         "route53resolver:*",
         "securityhub:*",


### PR DESCRIPTION
Allows terraform to create the trust anchor and profile for Roles Anywhere.  Until this is merged, dr2-ingest won't be able to be applied on prd as there will be an error for terraform role permissions for creating the trust anchor.  Manually applied on intg already.

Also updates ecr permissions to allow access for the role

A future PR will remove the iam_user and iam_group permission, still need those for terraform to check state and destroy them in future.