### PR TITLE
Fix lifecycle policy.

### DIFF
--- a/templates/ecr/lifecycle_policy.json.tpl
+++ b/templates/ecr/lifecycle_policy.json.tpl
@@ -23,9 +23,8 @@
           "staging",
           "prod"
         ],
-        "countType": "sinceImagePushed",
-        "countUnit": "days",
-        "countNumber": 73000
+        "countType": "imageCountMoreThan",
+        "countNumber": 9999
       },
       "action": {
         "type": "expire"


### PR DESCRIPTION
Because of some odd way these policies are evaluated, the second rule
returned no results which meant that the third rule deleted everything,
including the ones we wanted to keep.

I'm not sure why this works but I've tested it in the console and it's
only removing the images we expect.
