### PR TITLE
Add repositories for cc tape confirmer.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:09fAczBASw/S5fgA35pxTCjtUgTn1Q+u9AxVdu9PYT0=",
     "h1:F9Ad0SflY+F0M+1F5FohJlQ573cVpCGn+c7hIvJRwkg=",
+    "h1:mn5tmUuTCiGsgdkCO6y/UFrLRQgt55AqLUqoHC/5qZ0=",
     "zh:626ada4e076bd852fb7fc3d0722f17a0eddd87356d94cfce8b3595a520e8d91d",
     "zh:6b31e0c5b60d830a623ae9cc7d8cf2db74f75735d83097c659607c8a6276adaf",
     "zh:774d02a1c5ddcc9b5efbfe86bc967f4af8a52b8cb5880b2f5d1b255e5b0868ba",

--- a/root.tf
+++ b/root.tf
@@ -237,9 +237,40 @@ module "custodial_copy_confirmer_repository" {
   image_source_url = "https://github.com/nationalarchives/dr2-custodial-copy"
 }
 
+module "custodial_copy_tape_confirmer_repository" {
+  source          = "git::https://github.com/nationalarchives/da-terraform-modules.git//ecr"
+  repository_name = "dr2-custodial-copy-tape-confirmer"
+  repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
+    allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy"
+    ]),
+    account_number = data.aws_caller_identity.current.account_id
+  })
+  lifecycle_policy = templatefile("${path.module}/templates/ecr/lifecycle_policy.json.tpl", {})
+  common_tags      = {}
+  image_source_url = "https://github.com/nationalarchives/dr2-custodial-copy"
+}
+
 module "custodial_copy_reconciler_repository" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules.git//ecr"
   repository_name = "dr2-custodial-copy-reconciler"
+  repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
+    allowed_principals = jsonencode([
+      "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.staging_account_number.value}:role/staging-dr2-custodial-copy",
+      "arn:aws:iam::${data.aws_ssm_parameter.prod_account_number.value}:role/prod-dr2-custodial-copy"
+    ]),
+    account_number = data.aws_caller_identity.current.account_id
+  })
+  common_tags      = {}
+  image_source_url = "https://github.com/nationalarchives/dr2-custodial-copy"
+}
+
+module "mock_tape_api_repository" {
+  source          = "git::https://github.com/nationalarchives/da-terraform-modules.git//ecr"
+  repository_name = "dr2-custodial-copy-mock-tape-api"
   repository_policy = templatefile("${path.module}/templates/ecr/cross_account_repository_policy.json.tpl", {
     allowed_principals = jsonencode([
       "arn:aws:iam::${data.aws_ssm_parameter.intg_account_number.value}:role/intg-dr2-custodial-copy",


### PR DESCRIPTION
This includes the repository for the confirmer itself and one for the mock tape API we're using on uat.
